### PR TITLE
달력 핵심 부분을 나눠서, 누락 되었던 대체 휴일 계산 부분 오류 수정.

### DIFF
--- a/src/js/core/calendar.circle.js
+++ b/src/js/core/calendar.circle.js
@@ -1,0 +1,18 @@
+import { circleList, lunarCircleList } from "./calendar.constants";
+import { nullish } from "./type";
+
+/**
+ * @public
+ */
+export function getLunarCircle(monthDateKey) {
+  return lunarCircleList[monthDateKey];
+}
+
+export function getCircle(monthDateKey) {
+  return circleList[monthDateKey];
+}
+
+export function addCircle(monthDateKey, circle = null) {
+  if (!monthDateKey || nullish(circle)) return;
+  circleList[monthDateKey] = circle;
+}

--- a/src/js/core/calendar.constants.js
+++ b/src/js/core/calendar.constants.js
@@ -1,0 +1,94 @@
+export const EMPTY_HOLIDAY_VALUE = "";
+
+export const NEW_YEAR_VALUE = "신정";
+export const MEMORIAL_DAY_VALUE = "현충일";
+
+export const LUNAR_NEW_YEAR_VALUE = "설날";
+export const LUNAR_THANKS_GIVING_VALUE = "추석";
+
+export const SOLAR_REMARK_ENTER_SPRING_KEY_LEAP = "2-3";
+export const SOLAR_REMARK_ENTER_SPRING_KEY = "2-4";
+export const SOLAR_REMARK_ENTER_SPRING_VALUE = "입춘 立春";
+
+export const LUNAR_INTERCALATION_MONTH = "윤달";
+export const LUNAR_CALENDAR = "음력";
+
+export const temporaryHolidayList = {
+  2025: {
+    "1-27": ["임시"],
+    "6-3": ["대선"],
+  },
+};
+
+export const holidayList = {
+  "1-1": [NEW_YEAR_VALUE],
+  "3-1": ["삼일절"],
+  "5-5": ["어린이날"],
+  "6-6": [MEMORIAL_DAY_VALUE],
+  "8-15": ["광복절"],
+  "10-3": ["개천절"],
+  "10-9": ["한글날"],
+  "12-25": ["성탄절"],
+};
+
+export const lunarHolidayList = {
+  "1-1": [LUNAR_NEW_YEAR_VALUE],
+  "4-8": ["부처님 오신 날"],
+  "8-15": [LUNAR_THANKS_GIVING_VALUE],
+};
+
+export const dayLabelList = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"];
+
+export const remarkList = {
+  "1-5": "소한 小寒",
+  "1-20": "대한 大寒",
+  "2-19": "우수 雨水",
+  "3-6": "경칩 驚蟄",
+  "3-21": "춘분 春分",
+  "4-5": "청명 淸明",
+  "4-20": "곡우 穀雨",
+  "5-6": "입하 立夏",
+  "5-21": "소만 小滿",
+  "6-6": "망종 芒種",
+  "6-22": "하지 夏至",
+  "7-7": "소서 小暑",
+  "7-23": "대서 大暑",
+  "8-8": "입추 立秋",
+  "8-23": "처서 處暑",
+  "9-8": "백로 白露",
+  "9-23": "추분 秋分",
+  "10-8": "한로 寒露",
+  "10-24": "상강 霜降",
+  "11-8": "입동 立冬",
+  "11-22": "소설 小雪",
+  "12-7": "대설 大雪",
+  "12-22": "동지 冬至",
+
+  "2-14": "발렌타인데이",
+  "3-14": "화이트데이",
+  "5-1": "근로자의 날",
+  "5-8": "어버이날",
+  "5-15": "스승의 날",
+  "7-17": "제헌절",
+  "11-11": "빼빼로데이",
+};
+
+export const lunarRemarkList = {
+  "1-15": "정월 대보름",
+  "3-3": "삼짇날",
+  "5-5": "단오",
+  "7-7": "칠석",
+  "7-15": "백중",
+};
+
+export const circleList = {
+  "9-6": true,
+  "9-8": true,
+  "7-28": true,
+};
+
+export const lunarCircleList = {
+  "4-8": true,
+  "10-15": true,
+  "7-18": true,
+};

--- a/src/js/core/calendar.holiday.js
+++ b/src/js/core/calendar.holiday.js
@@ -1,0 +1,142 @@
+import { nullish } from "./type";
+import {
+  EMPTY_HOLIDAY_VALUE,
+  holidayList,
+  LUNAR_NEW_YEAR_VALUE,
+  LUNAR_THANKS_GIVING_VALUE,
+  lunarHolidayList,
+  MEMORIAL_DAY_VALUE,
+  NEW_YEAR_VALUE,
+  temporaryHolidayList,
+} from "./calendar.constants";
+
+/**
+ * @private
+ */
+
+function mergeHolidayList(monthDateKey, targetList) {
+  if (!targetList?.length) return;
+  holidayList[monthDateKey] = [
+    ...getHoliday(monthDateKey, true),
+    ...targetList,
+  ];
+}
+
+function addHoliday(monthDateKey, target) {
+  if (!monthDateKey || nullish(target)) return;
+  mergeHolidayList(monthDateKey, [target]);
+}
+
+function addSubstituteHoliday({
+  year,
+  month,
+  date,
+  holidayName = null,
+  dayAfter = 1,
+  skipName = true,
+  suffix = "대체",
+}) {
+  if (nullish(holidayName)) {
+    return;
+  }
+  let day = new Date(year, month - 1, date);
+  if (day.getDay() === 0) {
+    day = new Date(year, month - 1, date + dayAfter);
+  } else if (day.getDay() === 6) {
+    day = new Date(year, month - 1, date + dayAfter + 1);
+  }
+  const substituteKey = `${day.getMonth() + 1}-${day.getDate()}`;
+  const substituteHolidayText = (
+    holidayName && !skipName ? [holidayName, suffix] : [suffix]
+  ).join(" ");
+  addHoliday(substituteKey, substituteHolidayText);
+}
+
+/**
+ * @public
+ */
+
+export function evaluateHolidayByYear(year) {
+  if (temporaryHolidayList[year]) {
+    Object.entries(temporaryHolidayList[year]).forEach(
+      ([monthDateKey, temporaryHolidays]) =>
+        mergeHolidayList(monthDateKey, temporaryHolidays)
+    );
+  }
+}
+
+export function addLunarHolidayToHolidayList(lunarMonthDateKey, monthDateKey) {
+  mergeHolidayList(monthDateKey, getLunarHoliday(lunarMonthDateKey));
+}
+
+export function getHoliday(monthDateKey, defaultEmptyList = false) {
+  if (!holidayList[monthDateKey]?.length) {
+    return defaultEmptyList ? [] : null;
+  }
+  return holidayList[monthDateKey];
+}
+
+export function hasHoliday(monthDateKey) {
+  return Array.isArray(holidayList[monthDateKey]);
+}
+
+export function getLunarHoliday(lunarMonthDateKey) {
+  return lunarHolidayList[lunarMonthDateKey] || null;
+}
+
+export function evaluateSubstituteHoliday(year, month, date, holidays) {
+  if (
+    !holidays?.length ||
+    holidays.includes(NEW_YEAR_VALUE) ||
+    holidays.includes(MEMORIAL_DAY_VALUE)
+  ) {
+    return;
+  }
+  if (
+    holidays.includes(LUNAR_NEW_YEAR_VALUE) ||
+    holidays.includes(LUNAR_THANKS_GIVING_VALUE)
+  ) {
+    let dayBefore = new Date(year, month - 1, date - 1);
+    let dayAfter = new Date(year, month - 1, date + 1);
+    if (dayBefore.getDay() === 0) {
+      dayBefore = new Date(year, month - 1, date - 1 + 3);
+    }
+    if (dayAfter.getDay() === 0) {
+      dayAfter = new Date(year, month - 1, date + 1 + 1);
+    }
+    addSubstituteHoliday({
+      year: dayBefore.getFullYear(),
+      month: dayBefore.getMonth() + 1,
+      date: dayBefore.getDate(),
+      holidayName: EMPTY_HOLIDAY_VALUE,
+      dayAfter: 0,
+      suffix: EMPTY_HOLIDAY_VALUE,
+    });
+    addSubstituteHoliday({
+      year: dayAfter.getFullYear(),
+      month: dayAfter.getMonth() + 1,
+      date: dayAfter.getDate(),
+      holidayName: EMPTY_HOLIDAY_VALUE,
+      dayAfter: 0,
+      suffix: EMPTY_HOLIDAY_VALUE,
+    });
+    return;
+  }
+  const day = new Date(year, month - 1, date);
+  const isWeekend = day.getDay() === 0 || day.getDay() === 6;
+  const isOverlapHolidays = holidays.length > 1;
+  if (!isWeekend && !isOverlapHolidays) {
+    return;
+  }
+  holidays.forEach((holidayName, index) => {
+    if (index === 0 && isOverlapHolidays) {
+      return;
+    }
+    addSubstituteHoliday({
+      year,
+      month,
+      date: date + index,
+      holidayName,
+    });
+  });
+}

--- a/src/js/core/calendar.js
+++ b/src/js/core/calendar.js
@@ -1,3 +1,5 @@
+import { dayLabelList } from "./calendar.constants";
+import { toLunarDate, toLunarLabel } from "./calendar.lunar";
 import {
   addLunarHolidayToHolidayList,
   evaluateHolidayByYear,
@@ -5,14 +7,12 @@ import {
   getHoliday,
   hasHoliday,
 } from "./calendar.holiday";
-import { dayLabelList } from "./calendar.constants";
 import {
   addRemark,
   evaluateLeapYearRemark,
   getLunarRemark,
   getRemark,
 } from "./calendar.remark";
-import { toLunarDate, toLunarLabel } from "./calendar.lunar";
 import { addCircle, getCircle, getLunarCircle } from "./calendar.circle";
 
 function toDayItem(year, month, date, day, lunar) {

--- a/src/js/core/calendar.js
+++ b/src/js/core/calendar.js
@@ -1,177 +1,34 @@
-import KoreanLunarCalendar from "korean-lunar-calendar";
-import { nullish } from "./type";
-
-const koreanLunarCalendar = new KoreanLunarCalendar();
-
-const dayLabel = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"];
-
-const remarkList = {
-  "1-5": "소한 小寒",
-  "1-20": "대한 大寒",
-  "2-19": "우수 雨水",
-  "3-6": "경칩 驚蟄",
-  "3-21": "춘분 春分",
-  "4-5": "청명 淸明",
-  "4-20": "곡우 穀雨",
-  "5-6": "입하 立夏",
-  "5-21": "소만 小滿",
-  "6-6": "망종 芒種",
-  "6-22": "하지 夏至",
-  "7-7": "소서 小暑",
-  "7-23": "대서 大暑",
-  "8-8": "입추 立秋",
-  "8-23": "처서 處暑",
-  "9-8": "백로 白露",
-  "9-23": "추분 秋分",
-  "10-8": "한로 寒露",
-  "10-24": "상강 霜降",
-  "11-8": "입동 立冬",
-  "11-22": "소설 小雪",
-  "12-7": "대설 大雪",
-  "12-22": "동지 冬至",
-
-  "2-14": "발렌타인데이",
-  "3-14": "화이트데이",
-  "5-1": "근로자의 날",
-  "5-8": "어버이날",
-  "5-15": "스승의 날",
-  "7-17": "제헌절",
-  "11-11": "빼빼로데이",
-};
-
-const NEW_YEAR = "신정";
-const MEMORIAL_DAY = "현충일";
-
-const holidayList = {
-  "1-1": NEW_YEAR,
-  "3-1": "삼일절",
-  "5-5": "어린이날",
-  "6-6": MEMORIAL_DAY,
-  "8-15": "광복절",
-  "10-3": "개천절",
-  "10-9": "한글날",
-  "12-25": "성탄절",
-};
-
-const LUNAR_NEW_YEAR = "설날";
-const LUNAR_THANKS_GIVING = "추석";
-
-const lunarHolidayList = {
-  "1-1": LUNAR_NEW_YEAR,
-  "4-8": "부처님 오신 날",
-  "8-15": LUNAR_THANKS_GIVING,
-};
-
-const lunarRemarkList = {
-  "1-15": "정월 대보름",
-  "3-3": "삼짇날",
-  "5-5": "단오",
-  "7-7": "칠석",
-  "7-15": "백중",
-};
-
-const temporaryHolidayList = {
-  2025: {
-    "1-27": "임시",
-    "6-3": "대선",
-  },
-};
-
-const circleList = {
-  "9-6": true,
-  "9-8": true,
-  "7-28": true,
-};
-
-const lunarCircleList = {
-  "4-8": true,
-  "10-15": true,
-  "7-18": true,
-};
-
-function evaluateSubstituteHoliday(year, month, date, holiday) {
-  if (!holiday || holiday === NEW_YEAR || holiday === MEMORIAL_DAY) {
-    return;
-  }
-  if (holiday === LUNAR_NEW_YEAR || holiday === LUNAR_THANKS_GIVING) {
-    const dayBefore = new Date(year, month - 1, date - 1);
-    const dayAfter = new Date(year, month - 1, date + 1);
-    holidayList[`${dayBefore.getMonth() + 1}-${dayBefore.getDate()}`] = "";
-    holidayList[`${dayAfter.getMonth() + 1}-${dayAfter.getDate()}`] = "";
-    if (dayBefore.getDay() === 0) {
-      addSubstituteHoliday(
-        dayBefore.getFullYear(),
-        dayBefore.getMonth() + 1,
-        dayBefore.getDate() + 3,
-        ""
-      );
-    }
-    if (dayAfter.getDay() === 0) {
-      addSubstituteHoliday(
-        dayAfter.getFullYear(),
-        dayAfter.getMonth() + 1,
-        dayAfter.getDate() + 1,
-        ""
-      );
-    }
-    return;
-  }
-  const day = new Date(year, month - 1, date);
-  if (holidayList[`${month}-${date}`]) {
-    console.debug(year, month, date, holidayList[`${month}-${date}`]);
-  }
-  if (day.getDay() !== 0 && day.getDay() !== 6) {
-    return;
-  }
-  addSubstituteHoliday(year, month, date, holiday);
-}
-
-function addSubstituteHoliday(year, month, date, holiday = "", dayAfter = 1) {
-  let day = new Date(year, month - 1, date);
-  if (day.getDay() === 0) {
-    day = new Date(year, month - 1, date + dayAfter);
-  } else if (day.getDay() === 6) {
-    day = new Date(year, month - 1, date + dayAfter + 1);
-  }
-  holidayList[`${day.getMonth() + 1}-${day.getDate()}`] =
-    `${!nullish(holiday) ? `${holiday} ` : ""}대체`;
-}
+import {
+  addLunarHolidayToHolidayList,
+  evaluateHolidayByYear,
+  evaluateSubstituteHoliday,
+  getHoliday,
+  hasHoliday,
+} from "./calendar.holiday";
+import { dayLabelList } from "./calendar.constants";
+import {
+  addRemark,
+  evaluateLeapYearRemark,
+  getLunarRemark,
+  getRemark,
+} from "./calendar.remark";
+import { toLunarDate, toLunarLabel } from "./calendar.lunar";
+import { addCircle, getCircle, getLunarCircle } from "./calendar.circle";
 
 function toDayItem(year, month, date, day, lunar) {
   const monthDateKey = `${month}-${date}`;
-  if (koreanLunarCalendar.setSolarDate(year, month, date)) {
-    const {
-      month: lunarMonth,
-      day: lunarDate,
-      intercalation,
-    } = koreanLunarCalendar.getLunarCalendar();
-    const lunarMonthDateKey = `${lunarMonth}-${lunarDate}`;
-    lunar = `${intercalation ? "윤달" : "음력"} ${lunarMonth}.${lunarDate}`;
-    if (lunarHolidayList[lunarMonthDateKey]) {
-      if (holidayList[monthDateKey]) {
-        addSubstituteHoliday(
-          year,
-          month,
-          date + 1,
-          holidayList[monthDateKey],
-          1
-        );
-      }
-      holidayList[monthDateKey] = [
-        holidayList[monthDateKey],
-        lunarHolidayList[lunarMonthDateKey],
-      ].filter((v) => !!v);
-    }
-    if (lunarRemarkList[lunarMonthDateKey]) {
-      remarkList[monthDateKey] = lunarRemarkList[lunarMonthDateKey];
-    }
-    if (lunarCircleList[lunarMonthDateKey]) {
-      circleList[monthDateKey] = true;
-    }
+  const { lunarMonthDateKey, lunarMonth, lunarDate, intercalation } =
+    toLunarDate(year, month, date);
+  if (lunarMonthDateKey) {
+    lunar = toLunarLabel(lunarMonth, lunarDate, intercalation);
+    addLunarHolidayToHolidayList(lunarMonthDateKey, monthDateKey);
+    addRemark(monthDateKey, getLunarRemark(lunarMonthDateKey));
+    addCircle(monthDateKey, getLunarCircle(lunarMonthDateKey));
   }
-  const remark = remarkList[monthDateKey] || null;
-  const holiday = holidayList[monthDateKey] || null;
-  const circle = circleList[monthDateKey] || null;
+  const remark = getRemark(monthDateKey);
+  const circle = getCircle(monthDateKey);
+  const holiday = getHoliday(monthDateKey);
+  const dayLabel = dayLabelList[day];
 
   evaluateSubstituteHoliday(year, month, date, holiday);
 
@@ -180,7 +37,7 @@ function toDayItem(year, month, date, day, lunar) {
     month,
     date,
     day,
-    dayLabel: dayLabel[day],
+    dayLabel,
     lunar,
     holiday,
     remark,
@@ -189,19 +46,16 @@ function toDayItem(year, month, date, day, lunar) {
 }
 
 function evaluateDayItem(dayItem) {
-  dayItem.holiday = nullish(holidayList[`${dayItem.month}-${dayItem.date}`])
-    ? dayItem.holiday
-    : holidayList[`${dayItem.month}-${dayItem.date}`];
+  const monthDateKey = `${dayItem.month}-${dayItem.date}`;
+  if (!hasHoliday(monthDateKey)) return dayItem;
+  dayItem.holiday = getHoliday(monthDateKey);
   return dayItem;
 }
 
 const CalendarCore = {
   mapYearPreprocessFormula(year) {
-    if (year % 4 === 1) {
-      remarkList["2-3"] = "입춘 立春";
-    } else {
-      remarkList["2-4"] = "입춘 立春";
-    }
+    evaluateLeapYearRemark(year);
+    evaluateHolidayByYear(year);
     return true;
   },
   toRowList(year, month) {
@@ -212,13 +66,6 @@ const CalendarCore = {
     const rowList = [];
     let row = [];
     const emptyDayItem = toDayItem(year, month, null, row.length, null);
-    if (temporaryHolidayList[year]) {
-      Object.entries(temporaryHolidayList[year]).forEach(
-        ([monthDateKey, holiday]) => {
-          holidayList[monthDateKey] = holiday;
-        }
-      );
-    }
     for (let i = 0; i < firstDayOfWeek; i++) {
       row.push(emptyDayItem);
     }

--- a/src/js/core/calendar.lunar.js
+++ b/src/js/core/calendar.lunar.js
@@ -1,0 +1,40 @@
+import KoreanLunarCalendar from "korean-lunar-calendar";
+import {
+  LUNAR_CALENDAR,
+  LUNAR_INTERCALATION_MONTH,
+} from "./calendar.constants";
+
+/**
+ * @private
+ */
+
+const koreanLunarCalendar = new KoreanLunarCalendar();
+
+/**
+ * @public
+ */
+export function toLunarDate(year, month, date) {
+  const result = {
+    lunarMonth: null,
+    lunarDate: null,
+    lunarMonthDateKey: null,
+    intercalation: null,
+  };
+  if (!koreanLunarCalendar.setSolarDate(year, month, date)) {
+    return result;
+  }
+  const {
+    month: lunarMonth,
+    day: lunarDate,
+    intercalation,
+  } = koreanLunarCalendar.getLunarCalendar();
+  result.lunarMonth = lunarMonth;
+  result.lunarDate = lunarDate;
+  result.lunarMonthDateKey = `${lunarMonth}-${lunarDate}`;
+  result.intercalation = intercalation;
+  return result;
+}
+
+export function toLunarLabel(month, date, intercalation) {
+  return `${intercalation ? LUNAR_INTERCALATION_MONTH : LUNAR_CALENDAR} ${month}.${date}`;
+}

--- a/src/js/core/calendar.remark.js
+++ b/src/js/core/calendar.remark.js
@@ -1,0 +1,30 @@
+import {
+  lunarRemarkList,
+  remarkList,
+  SOLAR_REMARK_ENTER_SPRING_KEY,
+  SOLAR_REMARK_ENTER_SPRING_KEY_LEAP,
+  SOLAR_REMARK_ENTER_SPRING_VALUE,
+} from "./calendar.constants";
+import { nullish } from "./type";
+
+export function evaluateLeapYearRemark(year) {
+  if (year % 4 === 1) {
+    remarkList[SOLAR_REMARK_ENTER_SPRING_KEY_LEAP] =
+      SOLAR_REMARK_ENTER_SPRING_VALUE;
+  } else {
+    remarkList[SOLAR_REMARK_ENTER_SPRING_KEY] = SOLAR_REMARK_ENTER_SPRING_VALUE;
+  }
+}
+
+export function getLunarRemark(monthDateKey) {
+  return lunarRemarkList[monthDateKey] || null;
+}
+
+export function addRemark(monthDateKey, target) {
+  if (!monthDateKey || nullish(target)) return;
+  remarkList[monthDateKey] = target;
+}
+
+export function getRemark(monthDateKey) {
+  return remarkList[monthDateKey] || null;
+}


### PR DESCRIPTION
달력을 핵심 부분 외 음력, 휴일, 중요날짜 표시, 절기 부분을 전부 나누고, 핵심에서 해당 부분을 끌어와서 계산하도록 변경. 기존에 있던 대체 휴일 계산 부분과 공휴일 겹칠 때 계산 안 되던 문제도 해결.